### PR TITLE
Post-Edit Cleanup

### DIFF
--- a/internal/edist/app.go
+++ b/internal/edist/app.go
@@ -148,8 +148,8 @@ func errorCmd(e error) tea.Cmd {
 
 type redrawMsg struct{}
 
-func redrawCmd() tea.Cmd {
-	return func() tea.Msg { return redrawMsg{} }
+func redrawCmd() tea.Msg {
+	return redrawMsg{}
 }
 
 func newItemDelegate(keys *delegateKeyMap) list.DefaultDelegate {
@@ -173,7 +173,7 @@ func newItemDelegate(keys *delegateKeyMap) list.DefaultDelegate {
 						return errorCmd(err)
 					}
 				}
-				return redrawCmd()
+				return tea.Batch(redrawCmd, tea.HideCursor)
 			}
 		}
 		return nil

--- a/internal/edist/app.go
+++ b/internal/edist/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 )
 
 type sticky struct {
@@ -165,6 +166,15 @@ func newItemDelegate(keys *delegateKeyMap) list.DefaultDelegate {
 			switch {
 			case key.Matches(msg, keys.edit):
 				editted, err := edit(item.rtf)
+
+				// Hack: re-enable the altscreen by printing directly to
+				// stdout.
+				//
+				// Vim also runs in the altscreen and exits the altsceen on
+				// exit. As a result, we need to manually jump back in after
+				// Vim closes.
+				termenv.AltScreen()
+
 				if err != nil {
 					return errorCmd(err)
 				}


### PR DESCRIPTION
Very nice work on this!

This PR contains a couple small edits to keep stuff working properly after Vi/Vim exits:

* Hide the cursor after exiting the editor (it currently appears in the bottom left corner)
* Re-enter the altscreen after Vi/Vim exits

As a side note, "open file in external editor" functionality is something we'd ultimately like support in Bubble Tea. There's no timeline for the feature yet, but we can let you know when the feature arrives.

And again: nicely done!